### PR TITLE
Visualize data

### DIFF
--- a/make_sankey_diagram.py
+++ b/make_sankey_diagram.py
@@ -1,0 +1,104 @@
+import pandas as pd
+import plotly.graph_objects as go
+from dash import Dash, dcc, html, Input, Output
+
+# Read direction estimates
+df = pd.read_csv("data/line_outputs/Crosstown/direction_estimates.csv")
+
+# Read station mapping
+station_mapping = (
+    pd.read_csv("data/line_outputs/Crosstown/line_metadata.csv")
+      .set_index("sortorder")["stop_name"]
+      .to_dict()
+)
+
+# Unique months and days of the week for dropdown options
+months = df['Month'].unique()
+days_of_week = df['day_of_week'].unique()
+
+def create_sankey_diagram(data: pd.DataFrame, station_mapping: dict, hour: int):
+    """
+    Create a Sankey diagram for one hour of data.
+    """
+    # Map IDs → names
+    data = data.copy()
+    data['origin_name'] = data['origin'].map(station_mapping)
+    data['destination_name'] = data['destination'].map(station_mapping)
+
+    # All station names used as node labels
+    unique_labels = list(station_mapping.values())
+    label_to_index = {lab: idx for idx, lab in enumerate(unique_labels)}
+
+    # Build source / target index arrays
+    source_indices = data['origin_name'].map(label_to_index)
+    target_indices = data['destination_name'].map(label_to_index)
+
+    # Make the figure
+    fig = go.Figure(go.Sankey(
+        node=dict(
+            pad=15,
+            thickness=20,
+            line=dict(color="black", width=0.5),
+            label=unique_labels,
+        ),
+        link=dict(
+            source=source_indices,
+            target=target_indices,
+            value=data['estimated_ridership'],
+        )
+    ))
+
+    fig.update_layout(
+        title_text=f"Sankey Diagram of Subway Ridership — Hour {hour}",
+        font_size=10
+    )
+    return fig
+
+# Initialize the Dash app
+app = Dash(__name__)
+
+# Layout of the app
+app.layout = html.Div([
+    html.H1("Subway Ridership Sankey Diagram"),
+    dcc.Dropdown(
+        id='month-dropdown',
+        options=[{'label': f'Month {int(month)}', 'value': int(month)} for month in months],
+        value=1,  # Default value
+        clearable=False
+    ),
+    dcc.Dropdown(
+        id='day-dropdown',
+        options=[{'label': day, 'value': day} for day in days_of_week],
+        value='Monday',  # Default value
+        clearable=False
+    ),
+    dcc.Dropdown(
+        id='hour-dropdown',
+        options=[{'label': f'Hour {hour}', 'value': hour} for hour in range(1, 25)],  # Assuming 24 hours
+        value=1,  # Default value
+        clearable=False
+    ),
+    dcc.Graph(id='sankey-graph')
+])
+
+# Callback to update the Sankey diagram based on selected month, day, and hour
+@app.callback(
+    Output('sankey-graph', 'figure'),
+    Input('month-dropdown', 'value'),
+    Input('day-dropdown', 'value'),
+    Input('hour-dropdown', 'value')
+)
+def update_sankey(selected_month, selected_day, selected_hour):
+    # Filter for the selected month, day of the week, and hour
+    subset = df[
+        (df.Month == selected_month) &
+        (df.day_of_week == selected_day) &
+        (df.hour_of_day == selected_hour)
+    ]
+
+    subset = subset.groupby(["origin","destination","hour_of_day"]).sum().reset_index()
+    return create_sankey_diagram(subset, station_mapping, selected_hour)
+
+# Run the app
+if __name__ == '__main__':
+    app.run(debug=False)

--- a/visualizations.py
+++ b/visualizations.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import seaborn as sns
+import matplotlib
+matplotlib.use('TkAgg')  # Use TkAgg backend for interactive plots
+from matplotlib import pyplot as plt
+
+
+def plot_ridership_by_hour(df: pd.DataFrame, 
+                            x: str = "hour_of_day", 
+                            y: str = "estimated_ridership", 
+                            col: str = "day_of_week", 
+                            hue: str = "Month") -> None:
+    """
+    Generate a relational plot of estimated ridership by hour of the day, 
+    separated by day of the week and colored by month.
+
+    NOTE: Seaborn documentation: https://seaborn.pydata.org/tutorial/relational.html
+    The default behavior in seaborn is to aggregate the multiple measurements at each x value by plotting the mean and the 95% confidence interval around the mean:
+
+
+    Parameters:
+    - df (pd.DataFrame): The DataFrame containing the data to plot.
+    - x (str): The name of the column to be used for the x-axis (default is "hour_of_day").
+    - y (str): The name of the column to be used for the y-axis (default is "estimated_ridership").
+    - col (str): The name of the column to create separate plots for each unique value (default is "day_of_week").
+    - hue (str): The name of the column to color the lines by (default is "Month").
+
+    Returns:
+    - None: This function displays the plot and does not return any value.
+    """
+    sns.relplot(data=df, 
+                 x=x, 
+                 y=y, 
+                 col=col, 
+                 hue=hue, 
+                 kind="line")
+    
+    plt.show()
+
+
+# Load the dataset
+df = pd.read_csv("data/line_outputs/Crosstown/direction_estimates.csv")
+
+# Usage:
+# plot_ridership_by_hour(df)
+
+if __name__ == '__main__':
+    plot_ridership_by_hour(df)
+    # # Save the plot to a file
+    # plt.savefig("ridership_by_hour.png")
+    # print("Plot saved as ridership_by_hour.png")


### PR DESCRIPTION
# Overview
This PR visualize ridership data using a 
- Sankey diagram (passenger flows among stations)
- Searbon's relplot (Passenger flow by hour of the day, week of the day and month)

# How to run
## Sankey Diagram
To visualize the Sankey Diagram:
- please run `make_sankey_diagram.py`.
- Click on the link below (`Running on ...`), as shown in the terminal. This will open a new tab in your browser 
![image](https://github.com/user-attachments/assets/79c67759-8f26-40f3-ba7a-c3fcd0b376f0)

You should see a graph in your browser where you can interactively select the day, hour and month that you want to visualize (it could take ~1 minute to update the plot):

![image](https://github.com/user-attachments/assets/d0266da6-f714-4747-ad27-9e8600c273a2)

## Seaborn relplot
Please run `visualization.py`. This will create a graph like the one below (showing the mean and the 95% interval):
![image](https://github.com/user-attachments/assets/e6963c80-b92a-4940-94c1-1821856c8654)




